### PR TITLE
fixed getAll Semesters to sort by startDate

### DIFF
--- a/app/controllers/semester.controller.js
+++ b/app/controllers/semester.controller.js
@@ -52,12 +52,15 @@ exports.findAll = (req, res) => {
   const sortVar = req.query.sortVar;
   var order = [];
 
-  if (sortVar != undefined) {
+/* 
+if (sortVar != undefined) {
     order.push([sortVar, req.query.order]);
   }
+*/
+  order.push(["startDate", "DESC"])
 
   Semester.findAll({
-    order: order,
+    order: order
   })
     .then((data) => {
       res.send(data);


### PR DESCRIPTION
Changed get all Semesters to always sort by startDate.  I couldn't think of a time we would not want this so now it should be fixed nearly everywhere in the front end.