### PR TITLE
don't update user name from Google when logging in

### DIFF
--- a/app/controllers/auth.controller.js
+++ b/app/controllers/auth.controller.js
@@ -44,9 +44,10 @@ exports.login = async (req, res) => {
     .then(async (data) => {
       if (data != null) {
         // doing this to ensure that the user's name is the one listed with Google
+        // decide just to update the picture since we allow editing of names
         user = data.dataValues;
-        user.firstName = firstName;
-        user.lastName = lastName;
+        // user.firstName = firstName;
+        // user.lastName = lastName;
         user.picture = picture;
         await User.update(user, {
           where: { id: user.id },


### PR DESCRIPTION
Since we allow users to update the name we don't want Google to update it